### PR TITLE
Update tectonic to 0.3.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:latest as builder
 
 RUN apt-get update && apt-get install -y libfontconfig1-dev libgraphite2-dev libharfbuzz-dev libicu-dev zlib1g-dev
-RUN cargo install tectonic --force --vers 0.3.0
+RUN cargo install tectonic --force --vers 0.3.1
 
 WORKDIR /usr/src/tex
 RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.11/binaries/Linux/biber-linux_x86_64.tar.gz'

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y libfontconfig1-dev libgraphite2-dev lib
 RUN cargo install tectonic --force --vers 0.3.0
 
 WORKDIR /usr/src/tex
-RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.14/binaries/Linux/biber-linux_x86_64.tar.gz'
+RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.11/binaries/Linux/biber-linux_x86_64.tar.gz'
 RUN tar -xvzf biber-linux_x86_64.tar.gz
 RUN chmod +x biber
 RUN cp biber /usr/bin/biber

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update && apt-get install -y libfontconfig1-dev libgraphite2-dev lib
 RUN cargo install tectonic --force --vers 0.3.0
 
 WORKDIR /usr/src/tex
-RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.11/binaries/Linux/biber-linux_x86_64.tar.gz'
+RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.14/binaries/Linux/biber-linux_x86_64.tar.gz'
 RUN tar -xvzf biber-linux_x86_64.tar.gz
 RUN chmod +x biber
 RUN cp biber /usr/bin/biber
@@ -19,9 +19,9 @@ RUN biber main
 RUN for f in *.tex; do tectonic $f; done
 
 # use a lightweight debian - no need for whole rust environment
-FROM debian:stretch-slim 
+FROM debian:buster-slim
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends libfontconfig1 libgraphite2-3 libharfbuzz0b libicu57 zlib1g libharfbuzz-icu0 libssl1.1 ca-certificates \
+    && apt-get install -y --no-install-recommends libfontconfig1 libgraphite2-3 libharfbuzz0b libicu63 zlib1g libharfbuzz-icu0 libssl1.1 ca-certificates \
     && apt-get clean && rm -rf /var/lib/apt/lists/* 
 
 # copy tectonic binary to new image

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM rust:latest as builder
 
 RUN apt-get update && apt-get install -y libfontconfig1-dev libgraphite2-dev libharfbuzz-dev libicu-dev zlib1g-dev
-RUN cargo install tectonic --force --vers 0.1.11
+RUN cargo install tectonic --force --vers 0.3.0
 
 WORKDIR /usr/src/tex
 RUN wget 'https://sourceforge.net/projects/biblatex-biber/files/biblatex-biber/2.11/binaries/Linux/biber-linux_x86_64.tar.gz'


### PR DESCRIPTION
Can you update the image on docker hub?

Needed to update to buster because something (tectonic, I guess) needed libicu63
I uploaded it to my own docker hub as `phpirates/tectonic-docker:0.3.0` to see if it works, and it seems to work: https://github.com/PHPirates/travis-ci-latex-pdf/runs/1346026811?check_suite_focus=true